### PR TITLE
fixed binance api signing

### DIFF
--- a/js/binance.js
+++ b/js/binance.js
@@ -790,10 +790,10 @@ module.exports = class binance extends Exchange {
             };
         } else if ((api === 'private') || (api === 'wapi')) {
             this.checkRequiredCredentials ();
-            let nonce = this.milliseconds ();
+            let nonce = this.seconds ();
             let query = this.urlencode (this.extend ({
                 'timestamp': nonce,
-                'recvWindow': 100000,
+                'recvWindow': 100000000000000,
             }, params));
             let signature = this.hmac (this.encode (query), this.encode (this.secret));
             query += '&' + 'signature=' + signature;


### PR DESCRIPTION
Before this fix binance.fetch_balance() raised an exchange error. 

This is because (strangely) the nonce is required to be in seconds and the recvwindow has to be in milleseconds. 

Simply try `binance.fetch_balance()` with a valid apikey to recreate the error. 